### PR TITLE
Remove dos window

### DIFF
--- a/video/CMakeLists.txt
+++ b/video/CMakeLists.txt
@@ -42,7 +42,11 @@ else()
 endif()
 
 # Command line executable with a simple OpenCV GUI
-add_executable(${APP_NAME} video_main.cpp run_application.cpp)
+if (WIN32)
+  add_executable(${APP_NAME} WIN32 video_main.cpp run_application.cpp)
+else()
+  add_executable(${APP_NAME} video_main.cpp run_application.cpp)
+endif()
 
 # Command line executable with a simple OpenCV GUI
 add_executable(${APP_NAME}_test test/video_test_main.cpp

--- a/video/run_application.h
+++ b/video/run_application.h
@@ -2,6 +2,7 @@
 
 namespace frank::video {
 
-[[noreturn]] extern void run_application(int argc, char const *argv[]);
+[[noreturn]] extern void run_application(int argc = 0,
+                                         char const *argv[] = nullptr);
 
 }

--- a/video/video_main.cpp
+++ b/video/video_main.cpp
@@ -2,11 +2,22 @@
 #include <cstring>
 #include <iostream>
 
+#include "config.h"
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 #include "run_application.h"
 #include "videoConfig.h"
 
+#ifndef WIN32
 int main(int argc, char const *argv[]) {
   std::cerr << argv[0] << " v" << VIDEO_VERSION_MAJOR << "."
             << VIDEO_VERSION_MINOR << '\n';
   frank::video::run_application(argc, argv);
 }
+#else
+int CALLBACK WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
+  frank::video::run_application();
+}
+#endif


### PR DESCRIPTION
on Microsoft Windows use WinMain instead of main as the application entry point so that no DOS command line window is shown to the user